### PR TITLE
Fix vite script paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "pnpm": "8.x"
   },
   "scripts": {
-    "dev": "cd client && vite",
+    "dev": "vite",
     "dev:full": "vite",
-    "build": "cd client && vite build",
-    "vercel-build": "cd client && vite build",
-    "preview": "cd client && vite preview",
-    "start": "cd client && vite preview",
+    "build": "vite build",
+    "vercel-build": "vite build",
+    "preview": "vite preview",
+    "start": "vite preview",
     "check": "tsc",
     "prepare": "echo 'Ready'"
   },


### PR DESCRIPTION
## Summary
- run Vite commands from repository root

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e4cc8b474832fa7678476a2d6df93